### PR TITLE
Fix diffusion layer to match paper specification

### DIFF
--- a/anemoi.sage
+++ b/anemoi.sage
@@ -252,7 +252,7 @@ class AnemoiPermutation:
             return [r[0]], [r[1]]
         else:
             x = self.mat*vector(x)
-            y = self.mat*vector(y[:-1] + [y[0]])
+            y = self.mat*vector(y[1:] + [y[0]])
             return list(x), list(y)
         
 


### PR DESCRIPTION
The paper mentions (section 5.1 Round Function / Diffusion Layer M, page 13) that the vector y is first passed through a permutation before applying the MDS matrix-vector product. The current implementation does not permute the coordinates of y, but instead only replaces the last one with with the first one.

This PR fixes the python implementation to match the paper specification.