### PR TITLE
Fix padding in sponge_hash()

### DIFF
--- a/anemoi.sage
+++ b/anemoi.sage
@@ -409,7 +409,9 @@ def sponge_hash(P, r, h, _x):
     else:
         sigma = 0
         x += [1]
-        x += (len(x) % r)*[0]
+        # if x is still not long enough, append 0s
+        if len(x) % r != 0:
+            x += (r - (len(x) % r))*[0]
     padded_x = [[x[pos+i] for i in range(0, r)]
                 for pos in range(0, len(x), r)]
     # absorption phase


### PR DESCRIPTION
The current padding in `sponge_hash()` can fail depending on the message length.
To reproduce the error, one can make an instantiation on the main branch of Anemoi with `n_cols = 4`, and then call
`sponge_hash(P=A, _x=[0,1,2,3,4,5], h=4, r=4)` which will yield the error.

This PR fixes the padding of the message in `sponge_hash()` to handle any message length.