### PR TITLE
Use BLS12-381 `Fr` modulus instead of `Fq` modulus in `anemoi.sage`

### DIFF
--- a/anemoi.sage
+++ b/anemoi.sage
@@ -605,7 +605,7 @@ if __name__ == "__main__":
 
     test_sponge(
         n_tests=10,
-        q=0x1A0111EA397FE69A4B1BA7B6434BACD764774B84F38512BF6730D2A0F6B0F6241EABFFFEB153FFFFB9FEFFFFFFFFAAAB, # BLS12-381 prime
+        q=0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001, # BLS12-381 scalar field prime
         alpha=5,
         n_cols=2,
         b=4,


### PR DESCRIPTION
The Sage script uses the `Fq` prime of BLS12-381 for testing. That prime is of 381-bit and is the prime modulus of the coordinates of the points (x, y) on BLS12-381.

However, in practice it is more common to run the SNARK-friendly function over the scalar field of the BLS12-381, meaning that the more common situation is to run it over `Fr` prime, which is noticeably smaller and is of only 254 bits. 

This PR proposes a change to replace the prime used in the Sage script test.