### PR TITLE
Relax digest size check

### DIFF
--- a/anemoi.sage
+++ b/anemoi.sage
@@ -413,7 +413,10 @@ def sponge_hash(P, r, h, _x):
     x = _x[:]
     if P.input_size() <= r:
         raise Exception("rate must be strictly smaller than state size!")
-    if h * P.F.cardinality().nbits() < 2 * P.security_level:
+    # Digest size check: we allow the digest size to be 3 bits shorter than
+    # the theoretical target, as commonly used finite fields usually have a
+    # characteristic size slightly under 2**256.
+    if h * P.F.cardinality().nbits() < 2 * P.security_level - 3:
         raise Exception(f"digest size is too small for the targeted security level!")
     # message padding (and domain separator computation)
     if len(x) % r == 0 and len(x) != 0:


### PR DESCRIPTION
Because finite fields used in crypto in practice have a characteristic slightly smaller than 256 bits, the digest size check when calling the sponge construction would be failing, hence allow for some wiggle room (to target 1 or 2 security bits less).