### PR TITLE
Question: missing transpose for l = 3 and l = 4?

### DIFF
--- a/anemoi.sage
+++ b/anemoi.sage
@@ -188,7 +188,7 @@ def get_mds(field, l):
                     mat.append(M_3(x_i, b))
                 elif l == 4:
                     mat.append(M_4(x_i, b))
-            mat = Matrix(field, l, l, mat)
+            mat = Matrix(field, l, l, mat).transpose()
             if is_mds(mat):
                 return mat
     else: # circulant matrix case


### PR DESCRIPTION
It seems it has been removed [here](https://github.com/anemoi-hash/anemoi-hash/commit/ec18e9e4fa75679404ea3c28cc1fc00f6f85105a#diff-74606d6f4214c842d42ce25aac513ab4aff98c57d3a162adb3348929f2775d46R187).

The figure 7, see below, for l = 3, gives us : `y2 = g x0 + x1 + x2`.
Let's take one round, with input `[0, 0, 0, 0, 0, 0]`. We have the following constants
- 39
- 17756515227822460609684409997111995494590448775258437999344446424780281143353
- 10188916128123599964772546147951904500865009616764646948187915341627970346879

Checking with ocaml-bls12-381 in utop:
```ocaml
let x0 = Bls12_381.Fr.of_string "39";;
let x1 = Bls12_381.Fr.of_string "17756515227822460609684409997111995494590448775258437999344446424780281143353";;
let x2 = Bls12_381.Fr.of_string "10188916128123599964772546147951904500865009616764646948187915341627970346879";;

let res = Bls12_381.Fr.to_string @@ Bls12_381.Fr.(of_string "7" * x0 + x1 + x2);;

27945431355946060574456956145063899995455458392023084947532361766408251490505
```
Which is the result we get with this PR.
I created a branch [dannywillems/delete-me-after-pr](https://github.com/anemoi-hash/anemoi-hash/tree/dannywillems/delete-me-after-pr) with this test example with the transpose. Here the output:
```
$ sage anemoi.sage
Test vectors for Anemoi instance over F_52435875175126190479447740508185965837690552500527637822603658699938581184513, n_rounds=12, n_cols=3, s=128
12
[46831969077685069848417038672541265663819973208847975762244110457865462734184, 36643052949561469883644492524589361162954963592083328814056195116237492387032, 27945431355946060574456956145063899995455458392023084947532361766408251490505, 14981678621464625851270783002338847382197300714436467949315331057125308909900, 48720959343719104324739338388885839802998711550637402773896395605948383052052, 11709610427641952476226704950218052763560489079301307464225164120801969364960]
```

![image](https://github.com/anemoi-hash/anemoi-hash/assets/6018454/33a7bbf3-3d44-494e-8c64-58d23c42967f)
